### PR TITLE
feat(repo): initialize repo used for anime list and detail page

### DIFF
--- a/src/repository/Anime/contract/getAnimeCharacter.contract.ts
+++ b/src/repository/Anime/contract/getAnimeCharacter.contract.ts
@@ -1,0 +1,52 @@
+/**
+ * WARN: Don't edit manually!
+ * generated using quicktype.io
+ */
+
+export interface GetAnimeCharacterAPIResponseType {
+  data?: Datum[];
+}
+
+interface Datum {
+  character?: Character;
+  favorites?: number;
+  role?: string;
+  voice_actors?: VoiceActor[];
+}
+
+interface Character {
+  images?: CharacterImages;
+  mal_id?: number;
+  name?: string;
+  url?: string;
+}
+
+interface CharacterImages {
+  jpg?: Jpg;
+  webp?: Webp;
+}
+
+interface Jpg {
+  image_url?: string;
+}
+
+interface Webp {
+  image_url?: string;
+  small_image_url?: string;
+}
+
+interface VoiceActor {
+  language?: string;
+  person?: Person;
+}
+
+interface Person {
+  images?: PersonImages;
+  mal_id?: number;
+  name?: string;
+  url?: string;
+}
+
+interface PersonImages {
+  jpg?: Jpg;
+}

--- a/src/repository/Anime/contract/getAnimeDetail.contract.ts
+++ b/src/repository/Anime/contract/getAnimeDetail.contract.ts
@@ -1,0 +1,129 @@
+/**
+ * WARN: Don't edit manually!
+ * generated using quicktype.io
+ */
+
+export interface GetAnimeDetailAPIResponseType {
+  data?: Data;
+}
+
+interface Data {
+  aired?: Aired;
+  airing?: boolean;
+  approved?: boolean;
+  background?: string;
+  broadcast?: Broadcast;
+  demographics?: unknown[];
+  duration?: string;
+  episodes?: number;
+  explicit_genres?: unknown[];
+  external?: External[];
+  favorites?: number;
+  genres?: Genre[];
+  images?: DataImages;
+  licensors?: Genre[];
+  mal_id?: number;
+  members?: number;
+  popularity?: number;
+  producers?: Genre[];
+  rank?: number;
+  rating?: string;
+  relations?: Relation[];
+  score?: number;
+  scored_by?: number;
+  season?: string;
+  source?: string;
+  status?: string;
+  streaming?: External[];
+  studios?: Genre[];
+  synopsis?: string;
+  theme?: Theme;
+  themes?: Genre[];
+  title?: string;
+  title_english?: string;
+  title_japanese?: string;
+  title_synonyms?: unknown[];
+  titles?: Title[];
+  trailer?: Trailer;
+  type?: string;
+  url?: string;
+  year?: number;
+}
+
+interface Aired {
+  from?: string;
+  prop?: Prop;
+  string?: string;
+  to?: string;
+}
+
+interface Prop {
+  from?: From;
+  to?: From;
+}
+
+interface From {
+  day?: number;
+  month?: number;
+  year?: number;
+}
+
+interface Broadcast {
+  day?: string;
+  string?: string;
+  time?: string;
+  timezone?: string;
+}
+
+interface External {
+  name?: string;
+  url?: string;
+}
+
+interface Genre {
+  mal_id?: number;
+  name?: string;
+  type?: string;
+  url?: string;
+}
+
+interface DataImages {
+  jpg?: Jpg;
+  webp?: Jpg;
+}
+
+interface Jpg {
+  image_url?: string;
+  large_image_url?: string;
+  small_image_url?: string;
+}
+
+interface Relation {
+  entry?: Genre[];
+  relation?: string;
+}
+
+interface Theme {
+  endings?: string[];
+  openings?: string[];
+}
+
+interface Title {
+  title?: string;
+  type?: string;
+}
+
+interface Trailer {
+  embed_url?: string;
+  images?: TrailerImages;
+  url?: string;
+  youtube_id?: string;
+}
+
+interface TrailerImages {
+  image_url?: string;
+  large_image_url?: string;
+  maximum_image_url?: string;
+  medium_image_url?: string;
+  small_image_url?: string;
+}

--- a/src/repository/Anime/contract/getAnimeEpisodes.contract.ts
+++ b/src/repository/Anime/contract/getAnimeEpisodes.contract.ts
@@ -1,0 +1,30 @@
+/**
+ * WARN: Don't edit manually!
+ * generated using quicktype.io
+ */
+
+export interface GetAnimeEpisodesAPIResponseType {
+  data?: Datum[];
+  pagination?: Pagination;
+}
+
+interface Datum {
+  episode?: string;
+  images?: Images;
+  mal_id?: number;
+  title?: string;
+  url?: string;
+}
+
+interface Images {
+  jpg?: Jpg;
+}
+
+interface Jpg {
+  image_url?: string;
+}
+
+interface Pagination {
+  has_next_page?: boolean;
+  last_visible_page?: number;
+}

--- a/src/repository/Anime/contract/getAnimeList.contract.ts
+++ b/src/repository/Anime/contract/getAnimeList.contract.ts
@@ -1,0 +1,124 @@
+/**
+ * WARN: Don't edit manually!
+ * generated using quicktype.io
+ */
+
+export interface GetAnimeListAPIResponseType {
+  data?: Datum[];
+  pagination?: Pagination;
+}
+
+interface Datum {
+  aired?: Aired;
+  airing?: boolean;
+  approved?: boolean;
+  background?: null | string;
+  broadcast?: Broadcast;
+  demographics?: Demographic[];
+  duration?: string;
+  episodes?: number;
+  explicit_genres?: unknown[];
+  favorites?: number;
+  genres?: Demographic[];
+  images?: DatumImages;
+  licensors?: Demographic[];
+  mal_id?: number;
+  members?: number;
+  popularity?: number;
+  producers?: Demographic[];
+  rank?: number | null;
+  rating?: string;
+  score?: number;
+  scored_by?: number;
+  season?: null | string;
+  source?: string;
+  status?: string;
+  studios?: Demographic[];
+  synopsis?: string;
+  themes?: Demographic[];
+  title?: string;
+  title_english?: null | string;
+  title_japanese?: string;
+  title_synonyms?: string[];
+  titles?: Title[];
+  trailer?: Trailer;
+  type?: string;
+  url?: string;
+  year?: number | null;
+}
+
+interface Aired {
+  from?: string;
+  prop?: Prop;
+  string?: string;
+  to?: null | string;
+}
+
+interface Prop {
+  from?: From;
+  to?: From;
+}
+
+interface From {
+  day?: number | null;
+  month?: number | null;
+  year?: number | null;
+}
+
+interface Broadcast {
+  day?: null | string;
+  string?: null | string;
+  time?: null | string;
+  timezone?: null | string;
+}
+
+interface Demographic {
+  mal_id?: number;
+  name?: string;
+  type?: string;
+  url?: string;
+}
+
+interface DatumImages {
+  jpg?: Jpg;
+  webp?: Jpg;
+}
+
+interface Jpg {
+  image_url?: string;
+  large_image_url?: string;
+  small_image_url?: string;
+}
+
+interface Title {
+  title?: string;
+  type?: string;
+}
+
+interface Trailer {
+  embed_url?: null | string;
+  images?: TrailerImages;
+  url?: null | string;
+  youtube_id?: null | string;
+}
+
+interface TrailerImages {
+  image_url?: null | string;
+  large_image_url?: null | string;
+  maximum_image_url?: null | string;
+  medium_image_url?: null | string;
+  small_image_url?: null | string;
+}
+
+interface Pagination {
+  current_page?: number;
+  has_next_page?: boolean;
+  items?: Items;
+  last_visible_page?: number;
+}
+
+interface Items {
+  count?: number;
+  per_page?: number;
+  total?: number;
+}

--- a/src/repository/Anime/types/index.ts
+++ b/src/repository/Anime/types/index.ts
@@ -1,0 +1,63 @@
+import type {
+  AnimeCharacterType,
+  AnimeDetailType,
+  AnimeEpisodesType,
+  AnimeListItemType
+} from '@/model/anime';
+import type { PaginationType } from '@/types/pagination';
+import type { GenericNormalizeResponseType } from '@/types/repository';
+
+/////////////////////////////////////////////////////////////////////////////
+// Get Anime List Contract
+/////////////////////////////////////////////////////////////////////////////
+
+export interface GetAnimeListFetchAPIArgs {
+  limit: number;
+  page: number;
+  query?: string;
+}
+
+export interface GetAnimeListResponseType {
+  animeList: AnimeListItemType[];
+  pagination: PaginationType;
+}
+
+export type GetAnimeListFetchAPIFnType = (
+  args: GetAnimeListFetchAPIArgs
+) => Promise<GenericNormalizeResponseType<GetAnimeListResponseType>>;
+
+/////////////////////////////////////////////////////////////////////////////
+// Get Anime Detail Contract
+/////////////////////////////////////////////////////////////////////////////
+
+export interface GetAnimeDetailFetchAPIArgs {
+  animeId: number;
+}
+
+export type GetAnimeDetailFetchAPIFnType = (
+  args: GetAnimeDetailFetchAPIArgs
+) => Promise<GenericNormalizeResponseType<AnimeDetailType>>;
+
+/////////////////////////////////////////////////////////////////////////////
+// Get Anime Character Contract
+/////////////////////////////////////////////////////////////////////////////
+
+export interface GetAnimeCharacterFetchAPIArgs {
+  animeId: number;
+}
+
+export type GetAnimeCharacterFetchAPIFnType = (
+  args: GetAnimeCharacterFetchAPIArgs
+) => Promise<GenericNormalizeResponseType<AnimeCharacterType[]>>;
+
+/////////////////////////////////////////////////////////////////////////////
+// Get Anime Episodes Contract
+/////////////////////////////////////////////////////////////////////////////
+
+export interface GetAnimeEpisodesFetchAPIArgs {
+  animeId: number;
+}
+
+export type GetAnimeEpisodesFetchAPIFnType = (
+  args: GetAnimeEpisodesFetchAPIArgs
+) => Promise<GenericNormalizeResponseType<AnimeEpisodesType[]>>;

--- a/src/repository/Anime/usecase/useGetAnimeCharacter/index.ts
+++ b/src/repository/Anime/usecase/useGetAnimeCharacter/index.ts
@@ -1,0 +1,79 @@
+import { useCallback } from 'react';
+
+import type { GetAnimeCharacterAPIResponseType } from '@/repository/Anime/contract/getAnimeCharacter.contract';
+import type { GetAnimeCharacterFetchAPIFnType } from '@/repository/Anime/types';
+
+import { castingError, throwError } from '@/utils/error';
+import { fetchAPI } from '@/utils/fetcher';
+import { safeParseToNumber, safeParseToString } from '@/utils/parse';
+import { constructURL } from '@/utils/url';
+import { MAXIMUM_CHARACTER_ANIME } from '@/constant/anime';
+import type { AnimeCharacterType } from '@/model/anime';
+
+const useGetAnimeCharacter = () => {
+  const handleOnFetchAPI: GetAnimeCharacterFetchAPIFnType = useCallback(
+    async (args) => {
+      const { animeId } = args;
+
+      try {
+        const url = constructURL(
+          `https://api.jikan.moe/v4/anime/${animeId}/characters`
+        );
+
+        const { error, response } =
+          await fetchAPI<GetAnimeCharacterAPIResponseType>(url, {
+            method: 'GET'
+          });
+
+        if (error) throw error;
+
+        if (!response || !response.data) {
+          return throwError('Unknown response');
+        }
+
+        const { data } = response;
+
+        const animeCharacters = data
+          .slice(0, 50)
+          .reduce<AnimeCharacterType[]>((result, item) => {
+            if (result.length >= MAXIMUM_CHARACTER_ANIME) return result;
+
+            if (item && item.character && item.character.name) {
+              const {
+                character: { images, name }
+              } = item;
+
+              let imageUrl = '';
+              if (images) {
+                if (images.webp?.image_url) {
+                  imageUrl = constructURL(images.webp?.image_url).toString();
+                } else if (images.jpg?.image_url) {
+                  imageUrl = constructURL(images.jpg?.image_url).toString();
+                }
+              }
+
+              result.push({
+                characterName: name,
+                favorites: safeParseToNumber(item.favorites),
+                image: imageUrl,
+                role: safeParseToString(item.role)
+              });
+            }
+
+            return result;
+          }, []);
+
+        return {
+          response: animeCharacters
+        };
+      } catch (e) {
+        return { error: castingError(e) };
+      }
+    },
+    []
+  );
+
+  return { fetchAPI: handleOnFetchAPI };
+};
+
+export default useGetAnimeCharacter;

--- a/src/repository/Anime/usecase/useGetAnimeDetail/index.ts
+++ b/src/repository/Anime/usecase/useGetAnimeDetail/index.ts
@@ -1,0 +1,42 @@
+import { useCallback } from 'react';
+
+import type { GetAnimeDetailAPIResponseType } from '@/repository/Anime/contract/getAnimeDetail.contract';
+import type { GetAnimeDetailFetchAPIFnType } from '@/repository/Anime/types';
+
+import { castingError, throwError } from '@/utils/error';
+import { fetchAPI } from '@/utils/fetcher';
+import { constructURL } from '@/utils/url';
+
+import { normalizeAnimeList } from './normalizer';
+
+const useGetAnimeDetail = () => {
+  const handleOnFetchAPI: GetAnimeDetailFetchAPIFnType = useCallback(
+    async (args) => {
+      const { animeId } = args;
+
+      try {
+        const url = constructURL(
+          `https://api.jikan.moe/v4/anime/${animeId}/full`
+        );
+
+        const { error, response } =
+          await fetchAPI<GetAnimeDetailAPIResponseType>(url, { method: 'GET' });
+
+        if (error) throw error;
+
+        if (!response || !response.data) {
+          return throwError('Unknown response');
+        }
+
+        return normalizeAnimeList(response);
+      } catch (e) {
+        return { error: castingError(e) };
+      }
+    },
+    []
+  );
+
+  return { fetchAPI: handleOnFetchAPI };
+};
+
+export default useGetAnimeDetail;

--- a/src/repository/Anime/usecase/useGetAnimeDetail/normalizer.ts
+++ b/src/repository/Anime/usecase/useGetAnimeDetail/normalizer.ts
@@ -1,0 +1,168 @@
+import type { GetAnimeDetailAPIResponseType } from '@/repository/Anime/contract/getAnimeDetail.contract';
+
+import { castingError, throwError } from '@/utils/error';
+import { safeParseToNumber, safeParseToString } from '@/utils/parse';
+import { constructURL } from '@/utils/url';
+import type {
+  AnimeAdditionalInfoType,
+  AnimeDetailType,
+  AnimeRatingType,
+  AnimeRelationItemType,
+  AnimeRelationType,
+  AnimeStreamingType
+} from '@/model/anime';
+import type { GenericNormalizeFnType } from '@/types/repository';
+import type { GetField } from '@/types/utils';
+
+type RawStudiosType = GetField<GetAnimeDetailAPIResponseType, 'data.studios'>;
+type RawProducerType = GetField<
+  GetAnimeDetailAPIResponseType,
+  'data.producers'
+>;
+
+const mappingAdditionalInfo = (
+  args: RawStudiosType | RawProducerType
+): AnimeAdditionalInfoType => {
+  if (args.length > 0) {
+    const formattedData: string[] = args.reduce<string[]>((result, item) => {
+      if (item && item.name) {
+        result.push(item.name);
+      }
+      return result;
+    }, []);
+
+    return { data: formattedData, formattedData: formattedData.join(', ') };
+  }
+
+  return { data: [], formattedData: '-' };
+};
+
+export const normalizeAnimeList: GenericNormalizeFnType<
+  AnimeDetailType,
+  GetAnimeDetailAPIResponseType
+> = (args) => {
+  const { data } = args;
+
+  try {
+    if (data && data.mal_id && data.title) {
+      const {
+        background,
+        duration,
+        episodes,
+        genres = [],
+        images,
+        mal_id: id,
+        producers = [],
+        relations = [],
+        score,
+        scored_by,
+        streaming: rawStreaming = [],
+        studios = [],
+        synopsis,
+        title,
+        type,
+        year
+      } = data;
+
+      // INFO: mapping image url
+
+      let imageUrl = '';
+      if (images) {
+        if (images.webp?.image_url) {
+          imageUrl = constructURL(images.webp?.image_url).toString();
+        } else if (images.jpg?.image_url) {
+          imageUrl = constructURL(images.jpg?.image_url).toString();
+        }
+      }
+
+      // INFO: mapping rating
+
+      const rating: AnimeRatingType = { rating: 0, totalParticipant: 0 };
+      if (score) rating.rating = score;
+      if (scored_by) rating.totalParticipant = scored_by;
+
+      // INFO: mapping genre
+
+      const genre = genres.reduce<string[]>((result, item) => {
+        if (item && item.name) {
+          result.push(item.name);
+        }
+        return result;
+      }, []);
+
+      // INFO: mapping streaming
+
+      const streaming = rawStreaming.reduce<AnimeStreamingType[]>(
+        (result, item) => {
+          if (item && item.name && item.url) {
+            result.push({ streamName: item.name, url: item.url });
+          }
+
+          return result;
+        },
+        []
+      );
+
+      // INFO: mapping anime relations
+
+      const animeRelations = relations.reduce<AnimeRelationType[]>(
+        (result, item) => {
+          if (
+            item &&
+            item.relation &&
+            Array.isArray(item.entry) &&
+            item.entry.length > 0
+          ) {
+            const { entry, relation } = item;
+
+            const formattedRelationItems = entry.reduce<
+              AnimeRelationItemType[]
+            >((result, relationItem) => {
+              if (relationItem && relationItem.mal_id && relationItem.name) {
+                const { mal_id, name } = relationItem;
+
+                result.push({ id: safeParseToString(mal_id), name });
+              }
+
+              return result;
+            }, []);
+
+            if (formattedRelationItems.length) {
+              result.push({ item: formattedRelationItems, relation });
+            }
+          }
+          return result;
+        },
+        []
+      );
+
+      const response: AnimeDetailType = {
+        animeRelations,
+        background: safeParseToString(background),
+        duration: safeParseToString(duration),
+        episodes: safeParseToNumber(episodes),
+        genre,
+        id: safeParseToString(id),
+        image: imageUrl,
+        producers: mappingAdditionalInfo(producers),
+        rating,
+        streaming,
+        studios: mappingAdditionalInfo(studios),
+        synopsis: safeParseToString(synopsis),
+        title,
+        type: safeParseToString(type),
+        year: safeParseToNumber(year)
+      };
+
+      return {
+        response
+      };
+    }
+
+    return throwError('data / pagination attribute is undefined');
+  } catch (e) {
+    return {
+      error: castingError(e)
+    };
+  }
+};

--- a/src/repository/Anime/usecase/useGetAnimeEpisodes/index.ts
+++ b/src/repository/Anime/usecase/useGetAnimeEpisodes/index.ts
@@ -1,0 +1,70 @@
+import { useCallback } from 'react';
+
+import type { GetAnimeEpisodesAPIResponseType } from '@/repository/Anime/contract/getAnimeEpisodes.contract';
+import type { GetAnimeEpisodesFetchAPIFnType } from '@/repository/Anime/types';
+
+import { castingError, throwError } from '@/utils/error';
+import { fetchAPI } from '@/utils/fetcher';
+import { constructURL } from '@/utils/url';
+import { MAXIMUM_EPISODES_ANIME } from '@/constant/anime';
+import type { AnimeEpisodesType } from '@/model/anime';
+
+const useGetAnimeEpisodes = () => {
+  const handleOnFetchAPI: GetAnimeEpisodesFetchAPIFnType = useCallback(
+    async (args) => {
+      const { animeId } = args;
+
+      try {
+        const url = constructURL(
+          `https://api.jikan.moe/v4/anime/${animeId}/videos/episodes`
+        );
+
+        const { error, response } =
+          await fetchAPI<GetAnimeEpisodesAPIResponseType>(url, {
+            method: 'GET'
+          });
+
+        if (error) throw error;
+
+        if (!response || !response.data) {
+          return throwError('Unknown response');
+        }
+
+        const { data } = response;
+
+        const animeEpisodes = data
+          .slice(0, 50)
+          .reduce<AnimeEpisodesType[]>((result, item) => {
+            if (result.length >= MAXIMUM_EPISODES_ANIME) return result;
+
+            if (item && item.episode && item.url && item.mal_id && item.title) {
+              const { images, mal_id, title, url } = item;
+
+              let imageUrl = '';
+              if (images && images.jpg && images.jpg.image_url) {
+                imageUrl = constructURL(images.jpg.image_url).toString();
+              }
+
+              result.push({
+                id: String(mal_id),
+                image: imageUrl,
+                title,
+                url
+              });
+            }
+
+            return result;
+          }, []);
+
+        return { response: animeEpisodes };
+      } catch (e) {
+        return { error: castingError(e) };
+      }
+    },
+    []
+  );
+
+  return { fetchAPI: handleOnFetchAPI };
+};
+
+export default useGetAnimeEpisodes;

--- a/src/repository/Anime/usecase/useGetAnimeList/index.ts
+++ b/src/repository/Anime/usecase/useGetAnimeList/index.ts
@@ -1,0 +1,46 @@
+import { useCallback } from 'react';
+
+import type { GetAnimeListAPIResponseType } from '@/repository/Anime/contract/getAnimeList.contract';
+import type { GetAnimeListFetchAPIFnType } from '@/repository/Anime/types';
+
+import { castingError, throwError } from '@/utils/error';
+import { fetchAPI } from '@/utils/fetcher';
+import { constructURL } from '@/utils/url';
+
+import { normalizeAnimeList } from './normalizer';
+
+const useGetAnimeList = () => {
+  const handleOnFetchAPI: GetAnimeListFetchAPIFnType = useCallback(
+    async (args) => {
+      const { limit, page, query } = args;
+
+      try {
+        const url = constructURL(`https://api.jikan.moe/v4/anime`, {
+          limit,
+          page,
+          q: query
+        });
+
+        const { error, response } = await fetchAPI<GetAnimeListAPIResponseType>(
+          url,
+          { method: 'GET' }
+        );
+
+        if (error) throw error;
+
+        if (!response || !response.data) {
+          return throwError('Unknown response');
+        }
+
+        return normalizeAnimeList(response);
+      } catch (e) {
+        return { error: castingError(e) };
+      }
+    },
+    []
+  );
+
+  return { fetchAPI: handleOnFetchAPI };
+};
+
+export default useGetAnimeList;

--- a/src/repository/Anime/usecase/useGetAnimeList/normalizer.ts
+++ b/src/repository/Anime/usecase/useGetAnimeList/normalizer.ts
@@ -1,0 +1,91 @@
+import type { GetAnimeListAPIResponseType } from '@/repository/Anime/contract/getAnimeList.contract';
+import type { GetAnimeListResponseType } from '@/repository/Anime/types';
+
+import { castingError, throwError } from '@/utils/error';
+import { safeParseToNumber, safeParseToString } from '@/utils/parse';
+import { constructURL } from '@/utils/url';
+import { LIMIT_ANIME_CARDS } from '@/constant/anime';
+import type { AnimeListItemType } from '@/model/anime';
+import type { PaginationType } from '@/types/pagination';
+import type { GenericNormalizeFnType } from '@/types/repository';
+
+export const normalizeAnimeList: GenericNormalizeFnType<
+  GetAnimeListResponseType,
+  GetAnimeListAPIResponseType
+> = (args) => {
+  const { data, pagination } = args;
+
+  try {
+    if (data && pagination) {
+      /**
+       * Mapping Anime List
+       */
+      const animeList = data.reduce<AnimeListItemType[]>((result, item) => {
+        if (result.length >= LIMIT_ANIME_CARDS) return result;
+
+        if (item && item.mal_id && item.title) {
+          const {
+            background,
+            episodes,
+            images,
+            mal_id,
+            score,
+            synopsis,
+            title
+          } = item;
+
+          let imageUrl = '';
+          if (images) {
+            if (images.webp?.image_url) {
+              imageUrl = constructURL(images.webp?.image_url).toString();
+            } else if (images.jpg?.image_url) {
+              imageUrl = constructURL(images.jpg?.image_url).toString();
+            }
+          }
+
+          let shortDesc = '';
+          if (background) shortDesc = background;
+          else if (synopsis) shortDesc = synopsis;
+
+          result.push({
+            episodes: safeParseToNumber(episodes),
+            id: safeParseToString(mal_id),
+            image: imageUrl,
+            rating: safeParseToNumber(score),
+            shortDesc,
+            title
+          });
+        }
+        return result;
+      }, []);
+
+      /**
+       * Mapping Pagination
+       */
+      const { current_page, items } = pagination;
+      const perPage = safeParseToNumber(items?.per_page);
+      const totalData = safeParseToNumber(items?.total);
+      const totalPage = Math.ceil(totalData / perPage);
+
+      const formattedPagination: PaginationType = {
+        page: safeParseToNumber(current_page),
+        perPage,
+        totalData,
+        totalPage
+      };
+
+      return {
+        response: {
+          animeList,
+          pagination: formattedPagination
+        }
+      };
+    }
+
+    return throwError('data / pagination attribute is undefined');
+  } catch (e) {
+    return {
+      error: castingError(e)
+    };
+  }
+};


### PR DESCRIPTION
## Description

- [x] Collect contract API using quicktype.io
- [x] Create contract repo + usecase
- [x] Create usecase (custom hooks)
  - [x] useGetAnimeList
  - [x] useGetAnimeDetail
  - [x] useGetAnimeCharacter
  - [x] useGetAnimeEpisodes



## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
