### PR TITLE
feat(anime-list): create anime list modules

### DIFF
--- a/src/modules/AnimeList/AnimeList.tsx
+++ b/src/modules/AnimeList/AnimeList.tsx
@@ -1,0 +1,93 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import Flex from '@/components/Flex';
+import Pagination from '@/components/Pagination';
+import Spinner from '@/components/Spinner';
+import Typography from '@/components/Typography';
+
+import { GRAY400, GRAY900, SECONDARY500 } from '@/constant/theme';
+
+import AnimeListCard from './components/AnimeListCard';
+import AnimeListNavbar from './components/AnimeListNavbar';
+import { useFetchAnimeList } from './usecase/useFetchAnimeList';
+import { styAnimeListModules } from './style';
+
+const AnimeListModules = () => {
+  const navigate = useNavigate();
+  const {
+    action: { fetchAnimelist, setKeyword },
+    state: { animeList, keyword, loading, pagination }
+  } = useFetchAnimeList();
+
+  const handleOnClickAnimeCard = useCallback(
+    (animeId: string) => {
+      navigate(`/anime/${animeId}`);
+    },
+    [navigate]
+  );
+
+  const handleOnPageChange = useCallback(
+    (page: number) => {
+      fetchAnimelist(page);
+
+      window.scrollTo({ behavior: 'smooth', top: 0 });
+    },
+    [fetchAnimelist]
+  );
+
+  return (
+    <section css={styAnimeListModules}>
+      <AnimeListNavbar onChange={setKeyword} value={keyword} />
+
+      <section className="anime-list__container">
+        {loading && (
+          <section className="anime-list__spinner">
+            <Spinner size={24} spinnerColor={SECONDARY500} />
+          </section>
+        )}
+
+        <>
+          <Typography.Paragraph
+            role="presentation"
+            aria-label="search result label"
+            margin="24px 0 8px"
+            modifier="heading-4"
+            color={GRAY900}
+          >
+            {keyword ? `Result for "${keyword}"` : 'All Anime'}
+          </Typography.Paragraph>
+
+          <Typography.Paragraph modifier="body-2" color={GRAY400}>
+            Search result&nbsp;
+            {loading ? '...' : `${pagination.totalData.toLocaleString()} Data`}
+          </Typography.Paragraph>
+        </>
+
+        <Flex
+          className="anime-list__content"
+          data-loading={loading}
+          flexWrap="wrap"
+          gap={24}
+        >
+          {animeList.map((item, index) => (
+            <Flex.Item key={`${item.title}-${index}-${item.id}`}>
+              <AnimeListCard {...item} onClickCard={handleOnClickAnimeCard} />
+            </Flex.Item>
+          ))}
+        </Flex>
+
+        {pagination.totalData > 0 && (
+          <Pagination
+            className="anime-list__pagination"
+            {...pagination}
+            onPageChange={handleOnPageChange}
+            disable={loading}
+          />
+        )}
+      </section>
+    </section>
+  );
+};
+
+export default AnimeListModules;

--- a/src/modules/AnimeList/Lazy.tsx
+++ b/src/modules/AnimeList/Lazy.tsx
@@ -1,0 +1,7 @@
+import loadable from '@loadable/component';
+
+const AnimeListModulesLazy = loadable(
+  () => import(/* webpackChunkName: "anime-list-modules" */ './AnimeList')
+);
+
+export default AnimeListModulesLazy;

--- a/src/modules/AnimeList/__tests__/AnimeList.test.tsx
+++ b/src/modules/AnimeList/__tests__/AnimeList.test.tsx
@@ -1,0 +1,244 @@
+import type { PropsWithChildren } from 'react';
+import { Fragment } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within
+} from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+import AnimeListModules from '@/modules/AnimeList';
+import {
+  httpMock_AnimeList_customKeyword,
+  httpMock_AnimeList_page1,
+  httpMock_AnimeList_page2
+} from '@/repository/Anime/__mocks__/getAnimeList.mock';
+
+import { JestBuilder } from '@/utils/test';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+  const module = jest.requireActual('react-router-dom');
+
+  return {
+    __esModule: true,
+    ...module,
+    useNavigate: () => mockNavigate
+  };
+});
+
+const wrapper = (props: PropsWithChildren<unknown>) => {
+  return (
+    <MemoryRouter initialEntries={['/']} initialIndex={0}>
+      <Routes>
+        <Route path="/" element={<Fragment>{props.children}</Fragment>} />
+      </Routes>
+    </MemoryRouter>
+  );
+};
+
+describe('Testing Anime Detail Modules Component', () => {
+  beforeEach(jest.clearAllMocks);
+
+  it('Should be render correctly + simulate change pagination', async () => {
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === 'https://api.jikan.moe/v4/anime?limit=20&page=1&q=') {
+        return httpMock_AnimeList_page1;
+      }
+
+      if (req.url === 'https://api.jikan.moe/v4/anime?limit=20&page=2&q=') {
+        return httpMock_AnimeList_page2;
+      }
+
+      if (
+        req.url === 'https://api.jikan.moe/v4/anime?limit=20&page=1&q=eyeshield'
+      ) {
+        return httpMock_AnimeList_customKeyword;
+      }
+
+      return {};
+    });
+
+    render(<AnimeListModules />, { wrapper });
+
+    /**
+     * Check loading bar on initial render
+     */
+
+    const loading = await screen.findByRole('presentation', {
+      name: 'loading'
+    });
+    expect(loading).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(loading).not.toBeInTheDocument();
+    });
+
+    const searchResultLabel = screen.getByRole('presentation', {
+      name: 'search result label'
+    });
+    expect(searchResultLabel).toHaveTextContent('All Anime');
+
+    /**
+     * Check anime card list
+     */
+    const cardItems = screen.getAllByRole('region', {
+      name: 'anime list card'
+    });
+    expect(cardItems).toHaveLength(3);
+
+    expect(cardItems[0]).toHaveTextContent('Cowboy Bebop');
+    expect(cardItems[1]).toHaveTextContent('Cowboy Bebop: Tengoku no Tobira');
+    expect(cardItems[2]).toHaveTextContent('Trigun');
+
+    const pagination = screen.getByRole('region', { name: 'pagination' });
+    const paginationItem = within(pagination).getAllByRole('listitem');
+    const link = paginationItem[1].getElementsByTagName('a')[0];
+
+    /**
+     * Simulate redirect to page 2
+     */
+    await act(() => userEvent.click(link));
+
+    await waitFor(() => {
+      const reRendercardItems = screen.getAllByRole('region', {
+        name: 'anime list card'
+      });
+      expect(reRendercardItems).toHaveLength(3);
+      expect(searchResultLabel).toHaveTextContent('All Anime');
+
+      expect(reRendercardItems[0]).toHaveTextContent('Witch Hunter Robin');
+      expect(reRendercardItems[1]).toHaveTextContent('Bouken Ou Beet');
+      expect(reRendercardItems[2]).toHaveTextContent('Eyeshield 21');
+    });
+  });
+
+  it('Should be render correctly + simulate change keyword', async () => {
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === 'https://api.jikan.moe/v4/anime?limit=20&page=1&q=') {
+        return httpMock_AnimeList_page1;
+      }
+
+      if (req.url === 'https://api.jikan.moe/v4/anime?limit=20&page=2&q=') {
+        return httpMock_AnimeList_page2;
+      }
+
+      if (
+        req.url === 'https://api.jikan.moe/v4/anime?limit=20&page=1&q=eyeshield'
+      ) {
+        return httpMock_AnimeList_customKeyword;
+      }
+
+      return {};
+    });
+
+    render(<AnimeListModules />, { wrapper });
+
+    /**
+     * Check loading bar on initial render
+     */
+
+    const searchResultLabel = await screen.findByRole('presentation', {
+      name: 'search result label'
+    });
+    expect(searchResultLabel).toHaveTextContent('All Anime');
+
+    /**
+     * Check anime card list
+     */
+    const cardItems = screen.getAllByRole('region', {
+      name: 'anime list card'
+    });
+    expect(cardItems).toHaveLength(3);
+
+    expect(cardItems[0]).toHaveTextContent('Cowboy Bebop');
+    expect(cardItems[1]).toHaveTextContent('Cowboy Bebop: Tengoku no Tobira');
+    expect(cardItems[2]).toHaveTextContent('Trigun');
+
+    const navbar = screen.getByRole('region', { name: 'navbar' });
+    const textfieldInput = within(navbar).getByRole('textbox');
+
+    /**
+     * Simulate redirect to page 2
+     */
+    await act(() => {
+      fireEvent.change(textfieldInput, { target: { value: 'eyeshield' } });
+    });
+    jest.runAllTimers();
+
+    await waitFor(() => {
+      const reRendercardItems = screen.getAllByRole('region', {
+        name: 'anime list card'
+      });
+      expect(searchResultLabel).toHaveTextContent('Result for "eyeshield"');
+      expect(reRendercardItems).toHaveLength(3);
+
+      expect(reRendercardItems[0]).toHaveTextContent(
+        'Eyeshield 21: Maboroshi no Golden Bowl'
+      );
+      expect(reRendercardItems[1]).toHaveTextContent(
+        'Eyeshield 21: Jump Festa 2005 Special'
+      );
+      expect(reRendercardItems[2]).toHaveTextContent(
+        'Eyeshield 21: 21st Anniversary PV'
+      );
+    });
+  });
+
+  it('Simulate click card should be redirected to detail page', async () => {
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === 'https://api.jikan.moe/v4/anime?limit=20&page=1&q=') {
+        return httpMock_AnimeList_page1;
+      }
+
+      return {};
+    });
+
+    render(<AnimeListModules />, { wrapper });
+
+    /**
+     * Check loading bar on initial render
+     */
+
+    const loading = await screen.findByRole('presentation', {
+      name: 'loading'
+    });
+    expect(loading).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(loading).not.toBeInTheDocument();
+    });
+
+    const searchResultLabel = screen.getByRole('presentation', {
+      name: 'search result label'
+    });
+    expect(searchResultLabel).toHaveTextContent('All Anime');
+
+    /**
+     * Check anime card list
+     */
+    const cardItems = screen.getAllByRole('region', {
+      name: 'anime list card'
+    });
+    expect(cardItems).toHaveLength(3);
+
+    expect(cardItems[0]).toHaveTextContent('Cowboy Bebop');
+    expect(cardItems[1]).toHaveTextContent('Cowboy Bebop: Tengoku no Tobira');
+    expect(cardItems[2]).toHaveTextContent('Trigun');
+
+    /**
+     * Simulate click card
+     */
+    expect(mockNavigate).not.toHaveBeenCalled();
+    await act(() => userEvent.click(cardItems[1]));
+
+    JestBuilder.test(mockNavigate)
+      .toBeCalledTimes(1)
+      .nthCalledWith(1, '/anime/5');
+  });
+});

--- a/src/modules/AnimeList/__tests__/AnimeList.test.tsx
+++ b/src/modules/AnimeList/__tests__/AnimeList.test.tsx
@@ -79,7 +79,7 @@ describe('Testing Anime Detail Modules Component', () => {
       expect(loading).not.toBeInTheDocument();
     });
 
-    const searchResultLabel = screen.getByRole('presentation', {
+    const searchResultLabel = await screen.getByRole('presentation', {
       name: 'search result label'
     });
     expect(searchResultLabel).toHaveTextContent('All Anime');
@@ -151,7 +151,7 @@ describe('Testing Anime Detail Modules Component', () => {
     /**
      * Check anime card list
      */
-    const cardItems = screen.getAllByRole('region', {
+    const cardItems = await screen.findAllByRole('region', {
       name: 'anime list card'
     });
     expect(cardItems).toHaveLength(3);
@@ -171,8 +171,8 @@ describe('Testing Anime Detail Modules Component', () => {
     });
     jest.runAllTimers();
 
-    await waitFor(() => {
-      const reRendercardItems = screen.getAllByRole('region', {
+    await waitFor(async () => {
+      const reRendercardItems = await screen.findAllByRole('region', {
         name: 'anime list card'
       });
       expect(searchResultLabel).toHaveTextContent('Result for "eyeshield"');
@@ -214,7 +214,7 @@ describe('Testing Anime Detail Modules Component', () => {
       expect(loading).not.toBeInTheDocument();
     });
 
-    const searchResultLabel = screen.getByRole('presentation', {
+    const searchResultLabel = await screen.findByRole('presentation', {
       name: 'search result label'
     });
     expect(searchResultLabel).toHaveTextContent('All Anime');
@@ -222,7 +222,7 @@ describe('Testing Anime Detail Modules Component', () => {
     /**
      * Check anime card list
      */
-    const cardItems = screen.getAllByRole('region', {
+    const cardItems = await screen.findAllByRole('region', {
       name: 'anime list card'
     });
     expect(cardItems).toHaveLength(3);

--- a/src/modules/AnimeList/components/AnimeListCard/AnimeListCard.tsx
+++ b/src/modules/AnimeList/components/AnimeListCard/AnimeListCard.tsx
@@ -1,0 +1,110 @@
+import type { MouseEventHandler } from 'react';
+import { useCallback, useMemo } from 'react';
+
+import Card from '@/components/Card';
+import Flex from '@/components/Flex';
+import Icon from '@/components/Icon';
+import Images from '@/components/Images';
+import Typography from '@/components/Typography';
+
+import { GRAY300, GRAY500, SECONDARY500 } from '@/constant/theme';
+import type { AnimeListItemType } from '@/model/anime';
+import type { FithubIconType } from '@/types/icon';
+
+import { styAnimeListCard } from './style';
+
+interface AnimeListCardProps extends AnimeListItemType {
+  onClickCard: (animeId: string) => void;
+}
+
+interface AnimeAdditionalInfoType {
+  color: string;
+  icon: FithubIconType;
+  value: string;
+}
+
+const AnimeListCard = (props: AnimeListCardProps) => {
+  const { episodes, id, image, onClickCard, rating, shortDesc, title } = props;
+
+  const listItem = useMemo<Array<AnimeAdditionalInfoType>>(() => {
+    return [
+      {
+        color: SECONDARY500,
+        icon: 'star-fill',
+        value: String(rating)
+      },
+      {
+        color: GRAY300,
+        icon: 'bookmark-line',
+        value: `${episodes ? `${episodes} Episodes` : 'Coming Soon'}`
+      }
+    ];
+  }, [episodes, rating]);
+
+  const handleOnClickCard: MouseEventHandler<HTMLElement> = useCallback(
+    (e) => {
+      e.preventDefault();
+
+      onClickCard(id);
+    },
+    [id, onClickCard]
+  );
+
+  return (
+    <Card
+      aria-label="anime list card"
+      css={styAnimeListCard}
+      withPadding={false}
+      onClick={handleOnClickCard}
+    >
+      <div className="anime-card__image">
+        <Images
+          alt="anime image"
+          src={image}
+          size={['100%', '300px']}
+          objectFit="cover"
+        />
+      </div>
+
+      <div className="anime-card__content">
+        <Typography.H4
+          aria-label="anime list item title"
+          className="anime-card__title"
+          modifier="heading-4"
+          margin="0 0 8px"
+          ellipsis
+        >
+          {title}
+        </Typography.H4>
+
+        <Typography.Paragraph
+          modifier="body-2"
+          className="anime-card__desc"
+          color={GRAY500}
+          margin="0 0 16px"
+        >
+          {Boolean(shortDesc) && <>{shortDesc.slice(0, 40)}...</>}
+        </Typography.Paragraph>
+
+        <Flex gap={16} className="anime-card__info-bar">
+          {listItem.map((item) => (
+            <Flex.Item key={item.value}>
+              <Flex alignItems="center" gap={4}>
+                <Flex.Item>
+                  <Icon icon={item.icon} color={item.color} />
+                </Flex.Item>
+                <Flex.Item>
+                  <Typography.H4 modifier="body-3" color={GRAY500}>
+                    {item.value}
+                  </Typography.H4>
+                </Flex.Item>
+              </Flex>
+            </Flex.Item>
+          ))}
+        </Flex>
+      </div>
+    </Card>
+  );
+};
+
+export default AnimeListCard;

--- a/src/modules/AnimeList/components/AnimeListCard/__tests__/AnimeListCard.test.tsx
+++ b/src/modules/AnimeList/components/AnimeListCard/__tests__/AnimeListCard.test.tsx
@@ -1,0 +1,54 @@
+import type { ComponentProps } from 'react';
+
+import { act, render, screen, within } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+import AnimeListCard from '@/modules/AnimeList/components/AnimeListCard';
+
+import { JestBuilder } from '@/utils/test';
+
+type Props = ComponentProps<typeof AnimeListCard>;
+
+const onClickCardSpy = jest.fn();
+const MOCK_PROPS: Props = {
+  episodes: 145,
+  id: '15',
+  image: 'https://cdn.myanimelist.net/images/anime/1079/133529.webp',
+  onClickCard: onClickCardSpy,
+  rating: 7.92,
+  shortDesc:
+    'Eyeshield 21 was original scheduled to stream in North America on Toonami Jetstream and NFL Rush in collaboration with the National Football League, but the plan fell through and the anime made its debut only on Toonami Jetstream, which later dropped the series. It would then become available in its entirety on Crunchyroll. Sentai Filmworks later licensed and released the first 52 episodes on DVD from 2010 to 2011.',
+  title: 'Eyeshield 21'
+};
+
+describe('Testing Anime List Card Component', () => {
+  it('Should be render correctly', () => {
+    render(<AnimeListCard {...MOCK_PROPS} />);
+    const card = screen.getByRole('region', { name: 'anime list card' });
+
+    const image = within(card).getByAltText('anime image');
+    JestBuilder.test(image)
+      .toBeInTheDocument()
+      .toHaveAttribute('src', MOCK_PROPS.image);
+
+    const title = within(card).getByRole('heading', {
+      name: 'anime list item title'
+    });
+    JestBuilder.test(title)
+      .toBeInTheDocument()
+      .toHaveTextContent('Eyeshield 21');
+  });
+
+  it('Simulate click card should be onClickCard props invoked', async () => {
+    render(<AnimeListCard {...MOCK_PROPS} />);
+    const card = screen.getByRole('region', { name: 'anime list card' });
+
+    /**
+     * Simulate click card
+     */
+    expect(onClickCardSpy).not.toHaveBeenCalled();
+    await act(() => userEvent.click(card));
+
+    JestBuilder.test(onClickCardSpy).toBeCalledTimes(1).nthCalledWith(1, '15');
+  });
+});

--- a/src/modules/AnimeList/components/AnimeListCard/index.ts
+++ b/src/modules/AnimeList/components/AnimeListCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AnimeListCard';

--- a/src/modules/AnimeList/components/AnimeListCard/style.ts
+++ b/src/modules/AnimeList/components/AnimeListCard/style.ts
@@ -1,0 +1,42 @@
+import { css } from '@emotion/react';
+
+export const styAnimeListCard = css`
+  cursor: pointer;
+
+  .anime-card {
+    &__image {
+      position: relative;
+      display: block;
+      height: 250px;
+      overflow: hidden;
+
+      &::before {
+        content: '';
+        position: absolute;
+        display: block;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 200px;
+        z-index: 10;
+        background: linear-gradient(
+          0deg,
+          rgba(255, 255, 255, 1) 0%,
+          rgba(255, 255, 255, 0) 100%
+        );
+      }
+    }
+
+    &__content {
+      padding: 16px;
+    }
+
+    &__title {
+      max-width: 200px;
+    }
+
+    &__desc {
+      height: 34px;
+    }
+  }
+`;

--- a/src/modules/AnimeList/components/AnimeListNavbar/AnimeListNavbar.tsx
+++ b/src/modules/AnimeList/components/AnimeListNavbar/AnimeListNavbar.tsx
@@ -1,0 +1,45 @@
+import Container from '@/components/Container';
+import Flex from '@/components/Flex';
+import Images from '@/components/Images';
+import Textfield from '@/components/Textfield';
+
+import { styAnimeListNavbar } from './style';
+
+import illustrationLogo from '@/assets/logo.png';
+
+interface AnimeListNavbarProps {
+  onChange: (keyword: string) => void;
+  value: string;
+}
+
+const AnimeListNavbar = (props: AnimeListNavbarProps) => {
+  const { onChange, value } = props;
+
+  return (
+    <section aria-label="navbar" css={styAnimeListNavbar}>
+      <Container>
+        <Flex alignItems="center" gap={24}>
+          <Flex.Item>
+            <Images
+              alt="Anime Logo"
+              src={illustrationLogo}
+              size={['auto', 60]}
+            />
+          </Flex.Item>
+
+          <Flex.Item className="anime-list-navbar__textfield">
+            <Textfield.Default
+              onChange={onChange}
+              value={value}
+              icon="search"
+              allowClear
+              placeholder="Find your favorite anime..."
+            />
+          </Flex.Item>
+        </Flex>
+      </Container>
+    </section>
+  );
+};
+
+export default AnimeListNavbar;

--- a/src/modules/AnimeList/components/AnimeListNavbar/__tests__/AnimeListNavbar.test.tsx
+++ b/src/modules/AnimeList/components/AnimeListNavbar/__tests__/AnimeListNavbar.test.tsx
@@ -1,0 +1,57 @@
+import type { ComponentProps } from 'react';
+
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+
+import AnimeListNavbar from '@/modules/AnimeList/components/AnimeListNavbar';
+
+import { JestBuilder } from '@/utils/test';
+
+type Props = ComponentProps<typeof AnimeListNavbar>;
+
+const onChangeSpy = jest.fn();
+const MOCK_PROPS: Props = {
+  onChange: onChangeSpy,
+  value: ''
+};
+
+describe('Testing Anime List Navbar Component', () => {
+  it('Should be render correctly', () => {
+    render(<AnimeListNavbar {...MOCK_PROPS} />);
+    const navbar = screen.getByRole('region', { name: 'navbar' });
+
+    const image = within(navbar).getByAltText('Anime Logo');
+    expect(image).toBeInTheDocument();
+
+    const textfieldContainer = within(navbar).getByRole('region', {
+      name: 'textfield'
+    });
+    const textfieldInput = within(textfieldContainer).getByRole('textbox');
+    JestBuilder.test(textfieldInput)
+      .toBeInTheDocument()
+      .toHaveValue('')
+      .toHaveAttribute('placeholder', 'Find your favorite anime...')
+      .not.toHaveAttribute('disabled')
+      .not.toHaveFocus();
+  });
+
+  it('Simulate search keyword on textfield should be onChange props invoked', async () => {
+    jest.useFakeTimers();
+    render(<AnimeListNavbar {...MOCK_PROPS} />);
+
+    const navbar = screen.getByRole('region', { name: 'navbar' });
+    const textfieldInput = within(navbar).getByRole('textbox');
+
+    /**
+     * Simulate search text
+     */
+    expect(onChangeSpy).not.toHaveBeenCalled();
+    await act(() => {
+      fireEvent.change(textfieldInput, { target: { value: 'eyeshield' } });
+    });
+    jest.runAllTimers();
+
+    JestBuilder.test(onChangeSpy)
+      .toBeCalledTimes(1)
+      .nthCalledWith(1, 'eyeshield');
+  });
+});

--- a/src/modules/AnimeList/components/AnimeListNavbar/index.ts
+++ b/src/modules/AnimeList/components/AnimeListNavbar/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AnimeListNavbar';

--- a/src/modules/AnimeList/components/AnimeListNavbar/style.ts
+++ b/src/modules/AnimeList/components/AnimeListNavbar/style.ts
@@ -1,0 +1,20 @@
+import { css } from '@emotion/react';
+
+import { WHITE } from '@/constant/theme';
+
+export const styAnimeListNavbar = css`
+  width: 100%;
+  height: 76px;
+  padding: 8px 0;
+  background-color: ${WHITE};
+  box-shadow: 0px 2px 8px 0px rgba(0, 0, 0, 0.15);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+
+  .anime-list-navbar {
+    &__textfield {
+      flex: 1;
+    }
+  }
+`;

--- a/src/modules/AnimeList/index.ts
+++ b/src/modules/AnimeList/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Lazy';

--- a/src/modules/AnimeList/style.ts
+++ b/src/modules/AnimeList/style.ts
@@ -1,0 +1,59 @@
+import { css } from '@emotion/react';
+
+import { DEFAULT_DURATION, DEFAULT_TRANSITION, WHITE } from '@/constant/theme';
+
+export const styAnimeListModules = css`
+  margin-bottom: 100px;
+
+  .anime-list {
+    &__container {
+      width: 1024px;
+      margin: auto;
+    }
+
+    &__spinner {
+      position: fixed;
+      top: 150px;
+      box-shadow: 0 3px 12px rgba(0, 0, 0, 0.05);
+      width: fit-content;
+      padding: 10px;
+      border-radius: 50%;
+      background-color: ${WHITE};
+      z-index: 200;
+      left: 50%;
+      transform: translateX(-50%);
+    }
+
+    &__content {
+      position: relative;
+      margin: 24px 0;
+      transition: all ${DEFAULT_DURATION} ${DEFAULT_TRANSITION};
+
+      &::before {
+        content: '';
+        position: absolute;
+        z-index: 100;
+        width: 100%;
+        height: 100%;
+        display: none;
+      }
+
+      &[data-loading='true'] {
+        opacity: 0.5;
+
+        &::before {
+          display: block;
+        }
+      }
+
+      > section {
+        flex: 0 0 calc(25% - 18px);
+      }
+    }
+
+    &__pagination {
+      width: fit-content;
+      margin: 0 auto 24px;
+    }
+  }
+`;

--- a/src/modules/AnimeList/usecase/__tests__/useFetchAnimeList.test.tsx
+++ b/src/modules/AnimeList/usecase/__tests__/useFetchAnimeList.test.tsx
@@ -1,0 +1,234 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+import { useFetchAnimeList } from '@/modules/AnimeList/usecase/useFetchAnimeList';
+import {
+  httpMock_AnimeList_customKeyword,
+  httpMock_AnimeList_page1,
+  httpMock_AnimeList_page2
+} from '@/repository/Anime/__mocks__/getAnimeList.mock';
+
+describe('Testing Fetch Anime Detail Custom Hooks', () => {
+  beforeEach(jest.clearAllMocks);
+
+  it('Testing positive case (change pagination) - should be all data success to retrieve from API', async () => {
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === 'https://api.jikan.moe/v4/anime?limit=20&page=1&q=') {
+        return httpMock_AnimeList_page1;
+      }
+
+      if (req.url === 'https://api.jikan.moe/v4/anime?limit=20&page=2&q=') {
+        return httpMock_AnimeList_page2;
+      }
+
+      if (
+        req.url === 'https://api.jikan.moe/v4/anime?limit=20&page=1&q=eyeshield'
+      ) {
+        return httpMock_AnimeList_customKeyword;
+      }
+
+      return {};
+    });
+
+    const { result } = renderHook(useFetchAnimeList);
+    expect(result.current.state.loading).toBeTruthy();
+    expect(result.current.state.animeList).toHaveLength(0);
+
+    await waitFor(() => {
+      expect(result.current.state.loading).toBeFalsy();
+      expect(result.current.state.animeList).toStrictEqual([
+        {
+          episodes: 26,
+          id: '1',
+          image: 'https://cdn.myanimelist.net/images/anime/4/19644.jpg',
+          rating: 8.75,
+          shortDesc: expect.stringContaining(
+            'When Cowboy Bebop first aired in spring of 1998 on TV Tokyo, only episodes'
+          ),
+          title: 'Cowboy Bebop'
+        },
+        {
+          episodes: 1,
+          id: '5',
+          image: 'https://cdn.myanimelist.net/images/anime/1439/93480.webp',
+          rating: 8.38,
+          shortDesc: expect.stringContaining(
+            'Another day, another bounty—such is the life of'
+          ),
+          title: 'Cowboy Bebop: Tengoku no Tobira'
+        },
+        {
+          episodes: 26,
+          id: '6',
+          image: 'https://cdn.myanimelist.net/images/anime/7/20310.webp',
+          rating: 8.22,
+          shortDesc: expect.stringContaining(
+            'The Japanese release by Victor Entertainment has different openings relating'
+          ),
+          title: 'Trigun'
+        }
+      ]);
+      expect(result.current.state.pagination).toStrictEqual({
+        page: 1,
+        perPage: 20,
+        totalData: 26717,
+        totalPage: 1336
+      });
+    });
+
+    /**
+     * Simulate access page 2
+     */
+    await act(() => result.current.action.fetchAnimelist(2));
+
+    await waitFor(async () => {
+      expect(result.current.state.loading).toBeFalsy();
+      expect(result.current.state.animeList).toStrictEqual([
+        {
+          episodes: 26,
+          id: '7',
+          image: 'https://cdn.myanimelist.net/images/anime/10/19969.webp',
+          rating: 7.26,
+          shortDesc: expect.stringContaining(
+            'Robin Sena is a powerful craft user drafted into'
+          ),
+          title: 'Witch Hunter Robin'
+        },
+        {
+          episodes: 52,
+          id: '8',
+          image: 'https://cdn.myanimelist.net/images/anime/7/21569.webp',
+          rating: 7.05,
+          shortDesc: expect.stringContaining(
+            'It is the dark century and the people are suffering under the rule of the devil'
+          ),
+          title: 'Bouken Ou Beet'
+        },
+        {
+          episodes: 145,
+          id: '15',
+          image: 'https://cdn.myanimelist.net/images/anime/1079/133529.webp',
+          rating: 7.92,
+          shortDesc: expect.stringContaining(
+            'Eyeshield 21 was original scheduled to stream in North America on Toonami Jetstream and'
+          ),
+          title: 'Eyeshield 21'
+        }
+      ]);
+      expect(result.current.state.pagination).toStrictEqual({
+        page: 2,
+        perPage: 20,
+        totalData: 26717,
+        totalPage: 1336
+      });
+    });
+  });
+
+  it('Testing positive case (search data by keyword) - should be all data success to retrieve from API', async () => {
+    fetchMock.mockResponse(async (req) => {
+      if (req.url === 'https://api.jikan.moe/v4/anime?limit=20&page=1&q=') {
+        return httpMock_AnimeList_page1;
+      }
+
+      if (req.url === 'https://api.jikan.moe/v4/anime?limit=20&page=2&q=') {
+        return httpMock_AnimeList_page2;
+      }
+
+      if (
+        req.url === 'https://api.jikan.moe/v4/anime?limit=20&page=1&q=eyeshield'
+      ) {
+        return httpMock_AnimeList_customKeyword;
+      }
+
+      return {};
+    });
+
+    const { result } = renderHook(useFetchAnimeList);
+    expect(result.current.state.loading).toBeTruthy();
+    expect(result.current.state.animeList).toHaveLength(0);
+
+    await waitFor(() => {
+      expect(result.current.state.loading).toBeFalsy();
+      expect(result.current.state.animeList).toStrictEqual([
+        {
+          episodes: 26,
+          id: '1',
+          image: 'https://cdn.myanimelist.net/images/anime/4/19644.jpg',
+          rating: 8.75,
+          shortDesc: expect.stringContaining(
+            'When Cowboy Bebop first aired in spring of 1998 on TV Tokyo, only episodes'
+          ),
+          title: 'Cowboy Bebop'
+        },
+        {
+          episodes: 1,
+          id: '5',
+          image: 'https://cdn.myanimelist.net/images/anime/1439/93480.webp',
+          rating: 8.38,
+          shortDesc: expect.stringContaining(
+            'Another day, another bounty—such is the life of'
+          ),
+          title: 'Cowboy Bebop: Tengoku no Tobira'
+        },
+        {
+          episodes: 26,
+          id: '6',
+          image: 'https://cdn.myanimelist.net/images/anime/7/20310.webp',
+          rating: 8.22,
+          shortDesc: expect.stringContaining(
+            'The Japanese release by Victor Entertainment has different openings relating'
+          ),
+          title: 'Trigun'
+        }
+      ]);
+      expect(result.current.state.pagination).toStrictEqual({
+        page: 1,
+        perPage: 20,
+        totalData: 26717,
+        totalPage: 1336
+      });
+    });
+
+    /**
+     * Simulate change keyword
+     */
+    await act(() => result.current.action.setKeyword('eyeshield'));
+
+    await waitFor(async () => {
+      expect(result.current.state.loading).toBeFalsy();
+      expect(result.current.state.animeList).toStrictEqual([
+        {
+          episodes: 1,
+          id: '1317',
+          image: 'https://cdn.myanimelist.net/images/anime/6/6087.webp',
+          rating: 6.61,
+          shortDesc: expect.stringContaining(
+            'The Uraharajuku Boarders may have been knocked out of the Kantou'
+          ),
+          title: 'Eyeshield 21: Maboroshi no Golden Bowl'
+        },
+        {
+          episodes: 1,
+          id: '6418',
+          image: 'https://cdn.myanimelist.net/images/anime/12/32103.webp',
+          rating: 6.71,
+          shortDesc: 'A brief OVA about the Devil Bats training on an island.',
+          title: 'Eyeshield 21: Jump Festa 2005 Special'
+        },
+        {
+          episodes: 1,
+          id: '57979',
+          image: 'https://cdn.myanimelist.net/images/anime/1455/141180.webp',
+          rating: 0,
+          shortDesc: '',
+          title: 'Eyeshield 21: 21st Anniversary PV'
+        }
+      ]);
+      expect(result.current.state.pagination).toStrictEqual({
+        page: 1,
+        perPage: 3,
+        totalData: 4,
+        totalPage: 2
+      });
+    });
+  });
+});

--- a/src/modules/AnimeList/usecase/useFetchAnimeList.ts
+++ b/src/modules/AnimeList/usecase/useFetchAnimeList.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import useGetAnimeList from '@/repository/Anime/usecase/useGetAnimeList';
+
+import useAsyncState from '@/hooks/useAsyncState';
+import useMount from '@/hooks/useMount';
+
+import { LIMIT_ANIME_CARDS } from '@/constant/anime';
+import type { AnimeListItemType } from '@/model/anime';
+import type { PaginationType } from '@/types/pagination';
+
+export const useFetchAnimeList = () => {
+  const { fetchAPI } = useGetAnimeList();
+  const initialRender = useRef(true);
+  const [keyword, setKeyword] = useState('');
+  const [pagination, setPagination] = useState<PaginationType>({
+    page: 0,
+    perPage: 10,
+    totalData: 0,
+    totalPage: 0
+  });
+  const [{ loading, result: animeList = [] }, dispatch] = useAsyncState<
+    AnimeListItemType[]
+  >({
+    initialLoading: true,
+    initialValue: []
+  });
+
+  const handleOnFetchAnimeList = useCallback(
+    async (page: number) => {
+      dispatch.setLoading(true);
+
+      const { response } = await fetchAPI({
+        limit: LIMIT_ANIME_CARDS,
+        page,
+        query: keyword
+      });
+
+      if (response) {
+        const { animeList, pagination } = response;
+
+        dispatch.setValue(animeList);
+        setPagination({
+          page: pagination.page,
+          perPage: pagination.perPage,
+          totalData: pagination.totalData,
+          totalPage: pagination.totalPage
+        });
+      }
+    },
+    [dispatch, fetchAPI, keyword]
+  );
+
+  useEffect(() => {
+    if (initialRender.current) {
+      initialRender.current = false;
+      return;
+    }
+
+    handleOnFetchAnimeList(1);
+
+    // INFO: disable eslint cause prevent unused rerender if handleOnFetchAnimeList changed
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [keyword]);
+
+  /**
+   * Fetch Anime List On Did Mount
+   */
+  useMount(async () => handleOnFetchAnimeList(1));
+
+  const state = useMemo(() => {
+    return {
+      animeList,
+      keyword,
+      loading,
+      pagination
+    };
+  }, [animeList, keyword, loading, pagination]);
+
+  const action = useMemo(() => {
+    return {
+      fetchAnimelist: handleOnFetchAnimeList,
+      setKeyword
+    };
+  }, [handleOnFetchAnimeList]);
+
+  return { action, state };
+};

--- a/src/setupTest.ts
+++ b/src/setupTest.ts
@@ -4,3 +4,6 @@ import '@testing-library/jest-dom';
 
 dotenv.config({ path: '.env.test' });
 require('jest-fetch-mock').enableMocks();
+
+jest.retryTimes(5, { logErrorsBeforeRetry: true });
+jest.setTimeout(120000);


### PR DESCRIPTION
## Description

- [x] Create UI components & use case
- [x] Combine UI component & use case also create entry point component anime list page
- [x] Create UT all files relate anime list page

## Screenshot

![image](https://github.com/irfanandriansyah1997/anime-reader/assets/20946937/61efc61d-679b-4983-b3a5-d7c2296c4657)


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
